### PR TITLE
Refactor parser architecture in order to follow the cake pattern

### DIFF
--- a/src/main/scala/fr/inria/hopla/XHtmlParsing.scala
+++ b/src/main/scala/fr/inria/hopla/XHtmlParsing.scala
@@ -1,4 +1,4 @@
-import fr.inria.hopla.ast.AST
+import fr.inria.hopla.ast.{ASTImpl, ASTComponentImpl, AST, ASTComponent}
 import fr.inria.hopla.parser.XSDParser
 
 import scala.io.Source
@@ -14,9 +14,7 @@ object XHtmlParsing extends App {
 
   override def main (args: Array[String]) {
     val xml = new XMLEventReader(Source.fromURL("http://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xml).parse()
-    ast simplify()
-    // ast generate("./results/xhtml/")
+    val parser = new XSDParser with ASTComponentImpl
+    val ast = parser.parse(xml).asInstanceOf[ASTImpl]
   }
 }

--- a/src/main/scala/fr/inria/hopla/ast/AST.scala
+++ b/src/main/scala/fr/inria/hopla/ast/AST.scala
@@ -1,44 +1,46 @@
 package fr.inria.hopla.ast
 
 /**
-  * Abstract Syntax Tree which represents a scala project<br>
-  * Each Compilation Unit, represented by an <code>ASTFile</code>, can be generated
-  *
-  * @author Jérémy Bossut, Jonathan Geoffroy
-  */
-case class AST() {
-  var files:Map[String, ASTFile] = Map()
-
-  /**
-   * Add a file into AST
-   * @param file
-   */
-  private def addFile(file: ASTFile): Unit = {
-    files = files + (file.name -> file)
-  }
+ * @author Jérémy Bossut, Jonathan Geoffroy
+ */
+trait AST {
 
   /**
    * Add a file into AST if it doesn't already exist, return the existing file otherwise.
-   * @param file
+   * @param file the file to get or add
    * @tparam T type of the given file.
    * @return a file of type T.
    */
-  def getOrAddFile[T <: ASTFile](file : T) : T = {
-    files.get(file.name) match {
-      case None => {
-    	  addFile(file)
-    	  file
-      }
-      case f => f.get.asInstanceOf[T]
-    }
-  }
+  def getOrAddFile[T <: ASTFile](file: T): T
+
+  /**
+   *
+   * @param filename the name of the file to find
+   * @return the file if found, None otherwise.
+   */
+  def get(filename: String): Option[ASTFile]
 
   /**
    * Simplify the AST by removing redundant implementations
    */
-  def simplify(): Unit = {
-    for(file <- files.values) {
-      file.simplify()
-    }
-  }
+  def simplify(): Unit
+
+  /**
+   *
+   * @return the number of ASTFile contained by the AST
+   */
+  def size : Int
+
+  /**
+   * check if the AST contains an ASTFile named <code>filename</code>
+   * @param filename the name of the ASTFile to check
+   * @return true if ast contains an ASTFile named <code>filename</code>
+   */
+  def contains(filename : String) : Boolean
+
+  /**
+   *
+   * @return true if ast doesn't contain any ASTFile
+   */
+  def isEmpty: Boolean
 }

--- a/src/main/scala/fr/inria/hopla/ast/ASTComponent.scala
+++ b/src/main/scala/fr/inria/hopla/ast/ASTComponent.scala
@@ -1,0 +1,11 @@
+package fr.inria.hopla.ast
+
+/**
+ * Abstract Syntax Tree which represents a scala project<br>
+ * Each Compilation Unit, represented by an <code>ASTFile</code>, can be generated
+ *
+ * @author Jérémy Bossut, Jonathan Geoffroy
+ */
+trait ASTComponent {
+  val ast : AST
+}

--- a/src/main/scala/fr/inria/hopla/ast/ASTComponentImpl.scala
+++ b/src/main/scala/fr/inria/hopla/ast/ASTComponentImpl.scala
@@ -1,0 +1,12 @@
+package fr.inria.hopla.ast
+
+/**
+ * Real implementation of ASTComponent
+ * @see{ASTComponent}
+ * @author Jérémy Bossut, Jonathan Geoffroy
+ */
+trait ASTComponentImpl extends ASTComponent {
+
+  override val ast = new ASTImpl
+
+}

--- a/src/main/scala/fr/inria/hopla/ast/ASTField.scala
+++ b/src/main/scala/fr/inria/hopla/ast/ASTField.scala
@@ -5,5 +5,5 @@ package fr.inria.hopla.ast
  * @author Jérémy Bossut, Jonathan Geoffroy
  */
 class ASTField(name: String, fieldType: String) {
-  def getName = name
+  val getName = name
 }

--- a/src/main/scala/fr/inria/hopla/ast/ASTField.scala
+++ b/src/main/scala/fr/inria/hopla/ast/ASTField.scala
@@ -4,6 +4,5 @@ package fr.inria.hopla.ast
  * Representation of a class field in ASTClass
  * @author Jérémy Bossut, Jonathan Geoffroy
  */
-class ASTField(name: String, fieldType: String) {
-  val getName = name
+class ASTField(val name: String, fieldType: String) {
 }

--- a/src/main/scala/fr/inria/hopla/ast/ASTFile.scala
+++ b/src/main/scala/fr/inria/hopla/ast/ASTFile.scala
@@ -38,8 +38,8 @@ abstract case class ASTFile(name: String) {
    * @param astTrait the trait implemented by this ASTFile
    */
   def withTrait(astTrait: ASTTrait): Unit = {
-    traits = traits + astTrait
-    astTrait.subFiles = astTrait.subFiles + this
+      traits = traits + astTrait
+      astTrait.subFiles = astTrait.subFiles + this
   }
 
   /**

--- a/src/main/scala/fr/inria/hopla/ast/ASTFile.scala
+++ b/src/main/scala/fr/inria/hopla/ast/ASTFile.scala
@@ -38,8 +38,8 @@ abstract case class ASTFile(name: String) {
    * @param astTrait the trait implemented by this ASTFile
    */
   def withTrait(astTrait: ASTTrait): Unit = {
-      traits = traits + astTrait
-      astTrait.subFiles = astTrait.subFiles + this
+      traits += astTrait
+      astTrait.subFiles += this
   }
 
   /**

--- a/src/main/scala/fr/inria/hopla/ast/ASTImpl.scala
+++ b/src/main/scala/fr/inria/hopla/ast/ASTImpl.scala
@@ -1,0 +1,37 @@
+package fr.inria.hopla.ast
+
+/**
+ * @author Jérémy Bossut, Jonathan Geoffroy
+ */
+case class ASTImpl(files: scala.collection.mutable.Map[String, ASTFile]) extends AST {
+
+  def this() = this(scala.collection.mutable.Map[String, ASTFile]())
+  /**
+   * Add a file into AST
+   * @param file
+   */
+  private def addFile(file: ASTFile): Unit = {
+    files += (file.name -> file)
+  }
+
+  override def getOrAddFile[T <: ASTFile](file: T): T = {
+    files.get(file.name) match {
+      case None => {
+        addFile(file)
+        file
+      }
+      case f => f.get.asInstanceOf[T]
+    }
+  }
+
+  override def simplify(): Unit = {
+    for (file <- files.values) {
+      file.simplify()
+    }
+  }
+
+  override def contains(filename : String) : Boolean = files.contains(filename)
+  override def isEmpty: Boolean = files.isEmpty
+  override def size : Int = files.size
+  override def get(filename: String) : Option[ASTFile] = files.get(filename)
+}

--- a/src/main/scala/fr/inria/hopla/ast/ASTTrait.scala
+++ b/src/main/scala/fr/inria/hopla/ast/ASTTrait.scala
@@ -1,7 +1,8 @@
 package fr.inria.hopla.ast
 
 /**
- * Created by jonathan on 29/10/14.
+ * Representation of a scala trait in AST
+ * @author Jérémy Bossut, Jonathan Geoffroy
  */
 class ASTTrait(name : String = null) extends ASTFile(name) {
 }

--- a/src/main/scala/fr/inria/hopla/parser/processors/ASTClassProcessor.scala
+++ b/src/main/scala/fr/inria/hopla/parser/processors/ASTClassProcessor.scala
@@ -1,6 +1,6 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.{ASTFile, ASTClass, AST}
+import fr.inria.hopla.ast.{AST, ASTClass, ASTFile}
 
 import scala.xml.pull.EvElemStart
 

--- a/src/main/scala/fr/inria/hopla/parser/processors/ASTTraitProcessor.scala
+++ b/src/main/scala/fr/inria/hopla/parser/processors/ASTTraitProcessor.scala
@@ -1,6 +1,6 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.{ASTFile, ASTTrait, AST}
+import fr.inria.hopla.ast.{AST, ASTComponent, ASTFile, ASTTrait}
 
 import scala.xml.pull.EvElemStart
 

--- a/src/main/scala/fr/inria/hopla/parser/processors/ComplexTypeProcessor.scala
+++ b/src/main/scala/fr/inria/hopla/parser/processors/ComplexTypeProcessor.scala
@@ -1,6 +1,6 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.AST
+import fr.inria.hopla.ast.{AST, ASTComponent}
 
 import scala.xml.pull.EvElemStart
 

--- a/src/main/scala/fr/inria/hopla/parser/processors/SchemaProcessor.scala
+++ b/src/main/scala/fr/inria/hopla/parser/processors/SchemaProcessor.scala
@@ -1,6 +1,6 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.{ASTTrait, AST}
+import fr.inria.hopla.ast.{AST, ASTComponent, ASTTrait}
 
 import scala.xml.pull.EvElemStart
 

--- a/src/test/scala/fr/inria/hopla/ast/ASTTest.scala
+++ b/src/test/scala/fr/inria/hopla/ast/ASTTest.scala
@@ -9,37 +9,38 @@ import org.scalatest.{Matchers, FlatSpec}
 
 class ASTTest extends FlatSpec with Matchers with MockFactory {
   "An empty AST" should "empty" in {
-    assert(new AST().files.isEmpty)
+    assert(true)
+    new ASTImpl().isEmpty
   }
 
   "An empty AST" should "add a Trait" in {
     val traitMock = new ASTTrait("TestTrait")
-    val ast : AST = new AST()
+    val ast : ASTImpl = new ASTImpl()
     ast.getOrAddFile(traitMock)
-    assert(ast.files.size == 1 && ast.files.contains("TestTrait"))
+    assert(ast.contains("TestTrait"))
   }
 
   "An AST" should "add two different Traits" in {
     val firstTraitMock = new ASTTrait("FirstTraitMock")
     val secondTraitMock = new ASTTrait("SecondTraitMock")
 
-    val ast : AST = new AST()
+    val ast : ASTImpl = new ASTImpl()
     ast.getOrAddFile(firstTraitMock)
     ast.getOrAddFile(secondTraitMock)
-    assert( ast.files.size == 2 &&
-            ast.files.contains("FirstTraitMock") &&
-            ast.files.contains("SecondTraitMock"))
+    assert( ast.size == 2 &&
+            ast.contains("FirstTraitMock") &&
+            ast.contains("SecondTraitMock"))
   }
 
   "An AST" should "add the same Trait only once" in {
     val firstTraitMock = new ASTTrait("SameTraitName")
     val secondTraitMock = new ASTTrait("SameTraitName")
 
-    val ast : AST = new AST()
+    val ast : ASTImpl = new ASTImpl()
     ast.getOrAddFile(firstTraitMock)
     val returnedTrait = ast.getOrAddFile(secondTraitMock)
-    assert( ast.files.size == 1 &&
-            ast.files.contains("SameTraitName") &&
+    assert( ast.size == 1 &&
+            ast.contains("SameTraitName") &&
             returnedTrait.equals(firstTraitMock))
   }
 }

--- a/src/test/scala/fr/inria/hopla/parser/processors/ASTClassProcessorTest.scala
+++ b/src/test/scala/fr/inria/hopla/parser/processors/ASTClassProcessorTest.scala
@@ -1,6 +1,5 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.AST
 import org.scalatest.{Matchers, FlatSpec}
 import fr.inria.hopla.parser.XSDParser
 
@@ -14,30 +13,29 @@ class ASTClassProcessorTest extends FlatSpec with Matchers {
 
   "ASTClassProcessor" should "create a class when it process an element" in {
     val xsd = new XMLEventReader(Source.fromFile("src/test/resources/xsd/simpleElement.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xsd).parse()
+    val parser = new XSDParser with ASTComponentMock
 
-    assert(ast.files.contains("element"))
+    val ast = parser.parse(xsd)
+    assert(ast.contains("element"))
   }
 
   it should "create a class when it process an attributeGroup" in {
     val xsd = new XMLEventReader(Source.fromFile("src/test/resources/xsd/simpleAttributeGroup.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xsd).parse()
-
-    assert(ast.files.contains("attributeGroup"))
+    val parser = new XSDParser with ASTComponentMock
+    val ast = parser.parse(xsd)
+    assert(ast.contains("attributeGroup"))
   }
 
   it should "create a class which inherits another" in {
     val xsd = new XMLEventReader(Source.fromFile("src/test/resources/xsd/inheritedElement.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xsd).parse()
+    val parser = new XSDParser with ASTComponentMock
+    val ast = parser.parse(xsd)
 
-    assert( ast.files.contains("subClass") &&
-            ast.files.contains("superClass"))
+    assert( ast.contains("subClass") &&
+            ast.contains("superClass"))
 
-    val subClass = ast.files.get("subClass").get
-    val superClass = ast.files.get("superClass").get
+    val subClass = ast.get("subClass").get
+    val superClass = ast.get("superClass").get
     assert(subClass.getInheritsFrom equals Some(superClass))
   }
 }

--- a/src/test/scala/fr/inria/hopla/parser/processors/ASTComponentMock.scala
+++ b/src/test/scala/fr/inria/hopla/parser/processors/ASTComponentMock.scala
@@ -1,0 +1,10 @@
+package fr.inria.hopla.parser.processors
+
+import fr.inria.hopla.ast.{ASTImpl, ASTComponent}
+
+/**
+ * @author Jérémy Bossut, Jonathan Geoffroy
+ */
+trait ASTComponentMock extends ASTComponent {
+  override val ast = new ASTImpl
+}

--- a/src/test/scala/fr/inria/hopla/parser/processors/ASTTraitProcessorTest.scala
+++ b/src/test/scala/fr/inria/hopla/parser/processors/ASTTraitProcessorTest.scala
@@ -1,6 +1,6 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.{ASTTrait, AST}
+import fr.inria.hopla.ast.{ASTTrait, ASTComponentImpl}
 import org.scalatest.{Matchers, FlatSpec}
 import fr.inria.hopla.parser.XSDParser
 
@@ -10,26 +10,26 @@ import scala.xml.pull.XMLEventReader
 /**
  * @author Jérémy Bossut, Jonathan Geoffroy
  */
-class ASTTraitProcessorTest extends FlatSpec with Matchers {
+class ASTTraitProcessorTest extends FlatSpec with Matchers with ASTComponentMock {
 
   "ASTTraitProcessor" should "create a trait when it process a group" in {
     val xsd = new XMLEventReader(Source.fromFile("src/test/resources/xsd/simpleGroup.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xsd).parse()
+    val parser = new XSDParser with ASTComponentMock
+    val ast = parser.parse(xsd)
 
-    assert(ast.files.contains("group"))
+    assert(ast.contains("group"))
   }
 
   it should "create a trait which inherits another" in {
     val xsd = new XMLEventReader(Source.fromFile("src/test/resources/xsd/inheritedGroup.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xsd).parse()
+    val parser = new XSDParser with ASTComponentMock
+    val ast = parser.parse(xsd)
 
-    assert( ast.files.contains("subTrait") &&
-      ast.files.contains("superTrait"))
+    assert( ast.contains("subTrait") &&
+      ast.contains("superTrait"))
 
-    val subClass = ast.files.get("subTrait").get
-    val superClass = ast.files.get("superTrait").get.asInstanceOf[ASTTrait]
+    val subClass = ast.get("subTrait").get
+    val superClass = ast.get("superTrait").get.asInstanceOf[ASTTrait]
     assert(subClass.getTraits contains superClass)
   }
 }

--- a/src/test/scala/fr/inria/hopla/parser/processors/ChoiceProcessorTest.scala
+++ b/src/test/scala/fr/inria/hopla/parser/processors/ChoiceProcessorTest.scala
@@ -1,6 +1,6 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.{ASTTrait, AST}
+import fr.inria.hopla.ast.{ASTTrait, ASTComponentImpl}
 import org.scalatest.{Matchers, FlatSpec}
 import fr.inria.hopla.parser.XSDParser
 
@@ -10,17 +10,17 @@ import scala.xml.pull.XMLEventReader
 /**
  * @author Jérémy Bossut, Jonathan Geoffroy
  */
-class ChoiceProcessorTest extends FlatSpec with Matchers {
+class ChoiceProcessorTest extends FlatSpec with Matchers with ASTComponentMock {
   "ChoiceProcessor" should "create a trait which inherits a class" in {
     val xsd = new XMLEventReader(Source.fromFile("src/test/resources/xsd/choice.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xsd).parse()
+    val parser = new XSDParser with ASTComponentMock
+    val ast = parser.parse(xsd)
 
-    assert( ast.files.contains("group") &&
-            ast.files.contains("element"))
+    assert( ast.contains("group") &&
+            ast.contains("element"))
 
-    val subClass = ast.files.get("element").get
-    val superTrait = ast.files.get("group").get.asInstanceOf[ASTTrait]
+    val subClass = ast.get("element").get
+    val superTrait = ast.get("group").get.asInstanceOf[ASTTrait]
     assert(subClass.getTraits contains superTrait)
   }
 }

--- a/src/test/scala/fr/inria/hopla/parser/processors/ComplexTypeProcessorTest.scala
+++ b/src/test/scala/fr/inria/hopla/parser/processors/ComplexTypeProcessorTest.scala
@@ -1,6 +1,6 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.AST
+import fr.inria.hopla.ast.ASTComponentImpl
 import org.scalatest.{Matchers, FlatSpec}
 import fr.inria.hopla.parser.XSDParser
 
@@ -10,12 +10,12 @@ import scala.xml.pull.XMLEventReader
 /**
  * @author Jérémy Bossut, Jonathan Geoffroy
  */
-class ComplexTypeProcessorTest extends FlatSpec with Matchers {
+class ComplexTypeProcessorTest extends FlatSpec with Matchers with ASTComponentMock {
   "ComplexTypeProcessor" should "process a named marker by creating a trait" in {
     val xsd = new XMLEventReader(Source.fromFile("src/test/resources/xsd/namedComplexType.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xsd).parse()
+    val parser = new XSDParser with ASTComponentMock
+    val ast = parser.parse(xsd)
 
-    assert(ast.files.contains("complexType"))
+    assert(ast.contains("complexType"))
   }
 }

--- a/src/test/scala/fr/inria/hopla/parser/processors/ExtensionProcessorTest.scala
+++ b/src/test/scala/fr/inria/hopla/parser/processors/ExtensionProcessorTest.scala
@@ -1,6 +1,6 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.AST
+import fr.inria.hopla.ast.ASTComponentImpl
 import org.scalatest.{Matchers, FlatSpec}
 import fr.inria.hopla.parser.XSDParser
 
@@ -10,15 +10,15 @@ import scala.xml.pull.XMLEventReader
 /**
  * @author Jérémy Bossut, Jonathan Geoffroy
  */
-class ExtensionProcessorTest extends FlatSpec with Matchers {
+class ExtensionProcessorTest extends FlatSpec with Matchers with ASTComponentMock {
   "ExtensionProcessor" should "add fields into element" in {
     val xsd = new XMLEventReader(Source.fromFile("src/test/resources/xsd/extension.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xsd).parse()
+    val parser = new XSDParser with ASTComponentMock
+    val ast = parser.parse(xsd)
 
-    assert(ast.files.contains("element"))
+    assert(ast.contains("element"))
 
-    val elementTrait = ast.files.get("element").get
+    val elementTrait = ast.get("element").get
     val fields = elementTrait.getFields
     assert(fields.nonEmpty && fields(0).getName.equals("attrs"))
   }

--- a/src/test/scala/fr/inria/hopla/parser/processors/ExtensionProcessorTest.scala
+++ b/src/test/scala/fr/inria/hopla/parser/processors/ExtensionProcessorTest.scala
@@ -20,6 +20,6 @@ class ExtensionProcessorTest extends FlatSpec with Matchers with ASTComponentMoc
 
     val elementTrait = ast.get("element").get
     val fields = elementTrait.getFields
-    assert(fields.nonEmpty && fields(0).getName.equals("attrs"))
+    assert(fields.nonEmpty && fields(0).name.equals("attrs"))
   }
 }

--- a/src/test/scala/fr/inria/hopla/parser/processors/SchemaProcessorTest.scala
+++ b/src/test/scala/fr/inria/hopla/parser/processors/SchemaProcessorTest.scala
@@ -1,6 +1,6 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.AST
+import fr.inria.hopla.ast.ASTComponentImpl
 import org.scalatest.{Matchers, FlatSpec}
 import fr.inria.hopla.parser.XSDParser
 
@@ -10,12 +10,12 @@ import scala.xml.pull.XMLEventReader
 /**
  * @author Jérémy Bossut, Jonathan Geoffroy
  */
-class SchemaProcessorTest  extends FlatSpec with Matchers {
+class SchemaProcessorTest  extends FlatSpec with Matchers with ASTComponentMock {
   "SchemaProcessor" should "create a trait when it process a group" in {
     val xsd = new XMLEventReader(Source.fromFile("src/test/resources/xsd/schema.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xsd).parse()
+    val parser = new XSDParser with ASTComponentMock
+    val ast = parser.parse(xsd)
 
-    assert(ast.files.contains("schema"))
+    assert(ast.contains("schema"))
   }
 }

--- a/src/test/scala/fr/inria/hopla/parser/processors/SequenceProcessorTest.scala
+++ b/src/test/scala/fr/inria/hopla/parser/processors/SequenceProcessorTest.scala
@@ -21,6 +21,6 @@ class SequenceProcessorTest extends FlatSpec with Matchers with ASTComponentMock
 
     val elementTrait = ast.get("element").get
     val fields = elementTrait.getFields
-    assert(fields.nonEmpty && fields(0).getName.equals("attr1") && fields(1).getName.equals("attr2"))
+    assert(fields.nonEmpty && fields(0).name.equals("attr1") && fields(1).name.equals("attr2"))
   }
 }

--- a/src/test/scala/fr/inria/hopla/parser/processors/SequenceProcessorTest.scala
+++ b/src/test/scala/fr/inria/hopla/parser/processors/SequenceProcessorTest.scala
@@ -1,6 +1,6 @@
 package fr.inria.hopla.parser.processors
 
-import fr.inria.hopla.ast.AST
+import fr.inria.hopla.ast.ASTComponentImpl
 import org.scalatest.{Matchers, FlatSpec}
 import fr.inria.hopla.parser.XSDParser
 
@@ -10,16 +10,16 @@ import scala.xml.pull.XMLEventReader
 /**
  * @author Jérémy Bossut, Jonathan Geoffroy
  */
-class SequenceProcessorTest extends FlatSpec with Matchers {
+class SequenceProcessorTest extends FlatSpec with Matchers with ASTComponentMock {
 
   "SequenceProcessorTest" should "add fields into element" in {
     val xsd = new XMLEventReader(Source.fromFile("src/test/resources/xsd/sequence.xsd"))
-    val ast = new AST()
-    new XSDParser(ast, xsd).parse()
+    val parser = new XSDParser with ASTComponentMock
+    val ast = parser.parse(xsd)
 
-    assert(ast.files.contains("element"))
+    assert(ast.contains("element"))
 
-    val elementTrait = ast.files.get("element").get
+    val elementTrait = ast.get("element").get
     val fields = elementTrait.getFields
     assert(fields.nonEmpty && fields(0).getName.equals("attr1") && fields(1).getName.equals("attr2"))
   }


### PR DESCRIPTION
Although we have implemented the cake pattern, mocking is still impossible for unknown reasons.
Tests on parser remain more functional than unit.
